### PR TITLE
Correct input weight for P2SH-P2WPKH

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,8 @@
       
       const P2SH_OUT_SIZE = P2SH_P2WPKH_OUT_SIZE = P2SH_P2WSH_OUT_SIZE = 32;
       
-      const P2SH_P2WPKH_IN_SIZE = 91;
+      <!-- All segwit input sizes are reduced by 1 WU to account for the witness item counts being added for every input per the transaction header -->
+      const P2SH_P2WPKH_IN_SIZE = 90.75;
       
       const P2WPKH_IN_SIZE = 67.75;
       const P2WPKH_OUT_SIZE = 31;


### PR DESCRIPTION
It seems to me that the intention here is to give the conservative
estimate: the size of a high-r signature for ECDSA signatures, and
counting the witness item counter for non-segwit inputs when used
in conjunction with segwit inputs.

It seems to me that some of the input weights have already been reduced
by the corresponding 1 WU, but not all of them:

```
      const P2PKH_IN_SIZE = 148;
      const P2PKH_OUT_SIZE = 34;

      const P2SH_OUT_SIZE = P2SH_P2WPKH_OUT_SIZE = P2SH_P2WSH_OUT_SIZE = 32;

      const P2SH_P2WPKH_IN_SIZE = 91;

      const P2WPKH_IN_SIZE = 67.75;
      const P2WPKH_OUT_SIZE = 31;

      const P2WSH_OUT_SIZE = P2TR_OUT_SIZE = 43;

      const P2TR_IN_SIZE = 57.25;

      const PUBKEY_SIZE = 33;
      const SIGNATURE_SIZE = 72;
```

- The 148 B for P2PKH assumes high-r (which is equivalent to a 72-byte
  high-r signature)
- The 91 vB for [P2SH_P2WPKH assumes
  high-r](https://bitcoin.stackexchange.com/a/111393/5406) (which is
  equivalent to a 72-byte signature) and already includes the witness
  item counter.
- The 67.75 vB for P2WPKH either accounts for the witness item being
  added in the header or assumes a low-r. The [conservative
  estimate](https://bitcoin.stackexchange.com/a/100160/5406) (including
  witness item count and high-r) should be 68.0 vB.
- The 57.25 vB for [P2TR is low by
  1 WU](https://bitcoin.stackexchange.com/a/111396/5406), the signature
  size for Schnorr sigs is always 64 B. This could be interpreted as it
  already accounting for the witness item count being added via the
  header data.

Assuming the intention is to always do the conservative (high-r)
estimate, the numbers should work as is, except that
`P2SH_P2WPKH_IN_SIZE` should be set to `90.75` which would then mean
that the witness item count is always accounted for in the header for
all output types, and all segwit types are reduced by the corresponding
1 WU to prevent double counting, while assuming high-r.