### PR TITLE
virtual tx size needs to be rounded up according to BIP-141

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,6 +208,7 @@
         var txBytes = getTxOverheadExtraRawBytes(input_script, input_count) + txVBytes + (inputWitnessSize * input_count) * 3 / 4;
         var txWeight = txVBytes * 4;
 
+        txVBytes = Math.ceil(txVBytes);
         document.getElementById('txBytes').innerHTML = txBytes;
         document.getElementById('txVBytes').innerHTML = txVBytes;
         document.getElementById('txWeight').innerHTML = txWeight;


### PR DESCRIPTION
https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#transaction-size-calculations

`Virtual transaction size is defined as Transaction weight / 4 (rounded up to the next integer).`